### PR TITLE
Fix wrong concatenation warning

### DIFF
--- a/src/class-wc-gateway-btcpay.php
+++ b/src/class-wc-gateway-btcpay.php
@@ -906,7 +906,7 @@ function woocommerce_btcpay_init()
             
             $url = $this->api_url;
             $client->setUri($url);
-            $this->log('    [Info] Set url to ' + $this->api_url);
+            $this->log('    [Info] Set url to ' . $this->api_url);
 
             $curlAdapter = new \Bitpay\Client\Adapter\CurlAdapter();
 


### PR DESCRIPTION
PHP message: PHP Warning:  A non-numeric value encountered in wp-content/plugins/btcpay-for-woocommerce/class-wc-gateway-btcpay.php on line 909

Concatenation of string and string should be done with dot, not a plus sign.