### PR TITLE
Fix IPN callbacks

### DIFF
--- a/src/class-wc-gateway-btcpay.php
+++ b/src/class-wc-gateway-btcpay.php
@@ -994,7 +994,7 @@ function woocommerce_btcpay_init()
 
             $expected_invoiceId = get_post_meta($order_id, 'BTCPay_id', true);
 
-            if (false !== isset($expected_invoiceId) || true === empty($expected_invoiceId)) {
+            if (empty($expected_invoiceId)) {
                 $this->log('    [Info] Receiving IPN for an order which has no expected invoice ID, ignoring the IPN...');
                 return;
             }


### PR DESCRIPTION
The if did not make sense and was failing even for correctly set expected_invoiceId. empty should be enough according to PHP documentation, it includes isset.