### PR TITLE
Use the order number as BTCPay order id

### DIFF
--- a/src/class-wc-gateway-btcpay.php
+++ b/src/class-wc-gateway-btcpay.php
@@ -741,10 +741,11 @@ function woocommerce_btcpay_init()
             $order_url = $order->get_edit_order_url();
 
             $pos_data = array(
-                'Woocommerce' => array(
+                'WooCommerce' => array(
                     'Order ID' => $order_id,
                     'Order Number' => $order_number,
-                    'Order URL' => $order_url
+                    'Order URL' => $order_url,
+                    'Plugin Version' => constant("BTCPAY_VERSION")
                 )
             );
 
@@ -979,7 +980,7 @@ function woocommerce_btcpay_init()
             // The BTCPay order id is the WooCommerce order number, see $invoice->setOrderId in process_payment()
             $order_number = $invoice->getOrderId();
             // We get the actual WooCommerce ID from the pos data, see $invoice->setPosData in process_payment()
-            $order_id = $json['posData']['Woocommerce']['Order ID'];
+            $order_id = $json['posData']['WooCommerce']['Order ID'];
 
             $responseData = json_decode($client->getResponse()->getBody());
 

--- a/src/class-wc-gateway-btcpay.php
+++ b/src/class-wc-gateway-btcpay.php
@@ -979,8 +979,11 @@ function woocommerce_btcpay_init()
 
             // The BTCPay order id is the WooCommerce order number, see $invoice->setOrderId in process_payment()
             $order_number = $invoice->getOrderId();
+
             // We get the actual WooCommerce ID from the pos data, see $invoice->setPosData in process_payment()
-            $order_id = $json['posData']['WooCommerce']['Order ID'];
+            // The posData is a string and needs to be JSON decoded separately.
+            $posData = json_decode($json['posData'], true);
+            $order_id = $posData['WooCommerce']['Order ID'];
 
             $responseData = json_decode($client->getResponse()->getBody());
 


### PR DESCRIPTION
Follow-up to #53.

Because the BTCPay order id shows up as a reference in the invoices list, its inconvenient for merchants to see the actual ID instead of the order number, which they expect.

These changes reset the part from the first PR, where the order ID got used consistently. Now we are setting the order number as the ID again, to suit the merchants need for easier bookkeeping.

To accommodate for that, now the `ipn_callback` gets the actual order ID from the PoS data that's been set on invoice creation by the `process_payment` method.

This way we can hide the complexity without the need for a custom filter function to convert the order number to order id. This has been error prone and triggered the first PR.