### PR TITLE
Adding support for additional tokens as separate payment methods.

### DIFF
--- a/src/class-wc-gateway-btcpay.php
+++ b/src/class-wc-gateway-btcpay.php
@@ -253,19 +253,6 @@ function woocommerce_btcpay_init()
             return (false !== strpos($actualMethod, 'btcpay'));
         }
 
-      /**
-       * Determine if an additional token payment method is used.
-       *
-       * @return bool
-       */
-        public function is_additional_token_method()
-        {
-            if (false !== strpos($this->id, 'btcpay_')) {
-                return true;
-            }
-            return false;
-        }
-
         public function __destruct()
         {
         }
@@ -812,7 +799,7 @@ function woocommerce_btcpay_init()
             $invoice->setExtendedNotifications(true);
 
             // Handle additional tokens and enforce them for invoice payment.
-            if ($this->is_additional_token_method()) {
+            if (!empty($this->token_symbol)) {
                 $invoice->setPaymentCurrencies(array($this->token_symbol));
             }
 
@@ -835,7 +822,7 @@ function woocommerce_btcpay_init()
 
                 // For promotion tokens we need to set the price to 1 (per item quantity).
                 // The idea is that 1 token is like a voucher.
-                if ($this->is_additional_token_method() && $this->token_mode === 'promotion') {
+                if (!empty($this->token_symbol) && $this->token_mode === 'promotion') {
                     // Set the invoice currency to the promotion token.
                     $invoice->setCurrency(new \Bitpay\CurrencyUnrestricted($this->token_symbol));
                     // For each of the purchased items quantity we charge 1 token.

--- a/src/class-wc-gateway-btcpay.php
+++ b/src/class-wc-gateway-btcpay.php
@@ -266,23 +266,6 @@ function woocommerce_btcpay_init()
             return false;
         }
 
-      /**
-       * Check upload directory for a custom icon and return the full url if
-       * it exists.
-       *
-       * @param $filename
-       *   The filename to search for. e.g. bitcoin.png
-       * @return string|null
-       */
-        public function load_custom_icon($filename)
-        {
-            $uploads_storage = wp_get_upload_dir();
-            if (file_exists($uploads_storage['basedir'] . "/{$filename}")) {
-                return $uploads_storage['baseurl'] . "/{$filename}";
-            }
-            return null;
-        }
-
         public function __destruct()
         {
         }

--- a/src/class-wc-gateway-btcpay.php
+++ b/src/class-wc-gateway-btcpay.php
@@ -208,41 +208,40 @@ function woocommerce_btcpay_init()
             $this->is_initialized = true;
         }
 
-      /**
-       * Initializes additional tokens if any configured.
-       */
-        public function initialize_additional_tokens()
-        {
-          if ($additional_tokens = btcpay_get_additional_tokens()) {
-              foreach ($additional_tokens as $token) {
+		/**
+		 * Initializes additional tokens if any configured.
+		 */
+		public function initialize_additional_tokens() {
+			if ( $additional_tokens = btcpay_get_additional_tokens() ) {
+				foreach ( $additional_tokens as $token ) {
 
-                if (!class_exists($token['classname'])) {
-                  // Build the class structure.
-                  $classcode = "class {$token['classname']} extends WC_Gateway_BtcPay { ";
-                  $classcode .= "public \$token_mode;";
-                  $classcode .= "public \$token_symbol;";
-                  $classcode .= "public function __construct() { ";
-                  $classcode .=   "parent::__construct();";
-                  $classcode .=   "\$this->id = 'btcpay_{$token['symbol']}';";
-                  $classcode .=   "\$this->method_title = 'BTCPay Asset: {$token['symbol']}';";
-                  $classcode .=   "\$this->method_description = 'This is an additional asset managed by BTCPay.';";
-                  $classcode .=   "\$this->title = '{$token['name']}';";
-                  $classcode .=   "\$this->token_mode = '{$token['mode']}';";
-                  $classcode .=   "\$this->token_symbol = '{$token['symbol']}';";
-                  $classcode .=   "\$this->icon = '{$token['icon']}';";
-                  $classcode .=   "\$this->init_settings();";
-                  $classcode .=  "}";
-				  $classcode .=  "public function ipn_callback() { ";
-				  $classcode .=    "return;";
-				  $classcode .=  "}";
-                  $classcode .= "}";
+					if ( ! class_exists( $token['classname'] ) ) {
+						// Build the class structure.
+						$classcode = "class {$token['classname']} extends WC_Gateway_BtcPay { ";
+						$classcode .= "public \$token_mode;";
+						$classcode .= "public \$token_symbol;";
+						$classcode .= "public function __construct() { ";
+						$classcode .= "parent::__construct();";
+						$classcode .= "\$this->id = 'btcpay_{$token['symbol']}';";
+						$classcode .= "\$this->method_title = 'BTCPay Asset: {$token['symbol']}';";
+						$classcode .= "\$this->method_description = 'This is an additional asset managed by BTCPay.';";
+						$classcode .= "\$this->title = '{$token['name']}';";
+						$classcode .= "\$this->token_mode = '{$token['mode']}';";
+						$classcode .= "\$this->token_symbol = '{$token['symbol']}';";
+						$classcode .= "\$this->icon = '{$token['icon']}';";
+						$classcode .= "\$this->init_settings();";
+						$classcode .= "}";
+						$classcode .= "public function ipn_callback() { ";
+						$classcode .= "return;";
+						$classcode .= "}";
+						$classcode .= "}";
 
-                  // Initialize it on the fly.
-                  eval($classcode);
-                }
-              }
-          }
-        }
+						// Initialize it on the fly.
+						eval( $classcode );
+					}
+				}
+			}
+		}
 
         public function is_btcpay_payment_method($order)
         {

--- a/src/class-wc-gateway-btcpay.php
+++ b/src/class-wc-gateway-btcpay.php
@@ -232,6 +232,9 @@ function woocommerce_btcpay_init()
                   $classcode .=   "\$this->icon = '{$token['icon']}';";
                   $classcode .=   "\$this->init_settings();";
                   $classcode .=  "}";
+				  $classcode .=  "public function ipn_callback() { ";
+				  $classcode .=    "return;";
+				  $classcode .=  "}";
                   $classcode .= "}";
 
                   // Initialize it on the fly.

--- a/src/class-wc-gateway-btcpay.php
+++ b/src/class-wc-gateway-btcpay.php
@@ -201,21 +201,86 @@ function woocommerce_btcpay_init()
                 add_action('woocommerce_api_wc_gateway_btcpay', array($this, 'ipn_callback'));
             }
 
+            // Additional token initialization.
+            if (btcpay_get_additional_tokens()) {
+              $this->initialize_additional_tokens();
+            }
             $this->is_initialized = true;
+        }
+
+      /**
+       * Initializes additional tokens if any configured.
+       */
+        public function initialize_additional_tokens()
+        {
+          if ($additional_tokens = btcpay_get_additional_tokens()) {
+              foreach ($additional_tokens as $token) {
+
+                if (!class_exists($token['classname'])) {
+                  // Build the class structure.
+                  $classcode = "class {$token['classname']} extends WC_Gateway_BtcPay { ";
+                  $classcode .= "public \$token_mode;";
+                  $classcode .= "public \$token_symbol;";
+                  $classcode .= "public function __construct() { ";
+                  $classcode .=   "parent::__construct();";
+                  $classcode .=   "\$this->id = 'btcpay_{$token['symbol']}';";
+                  $classcode .=   "\$this->method_title = 'BTCPay Asset: {$token['symbol']}';";
+                  $classcode .=   "\$this->method_description = 'This is an additional asset managed by BTCPay.';";
+                  $classcode .=   "\$this->title = '{$token['name']}';";
+                  $classcode .=   "\$this->token_mode = '{$token['mode']}';";
+                  $classcode .=   "\$this->token_symbol = '{$token['symbol']}';";
+                  $classcode .=   "\$this->icon = '{$token['icon']}';";
+                  $classcode .=   "\$this->init_settings();";
+                  $classcode .=  "}";
+                  $classcode .= "}";
+
+                  // Initialize it on the fly.
+                  eval($classcode);
+                }
+              }
+          }
         }
 
         public function is_btcpay_payment_method($order)
         {
             $actualMethod = '';
-            if(method_exists($order, 'get_payment_method'))
-            {
+            if (method_exists($order, 'get_payment_method')) {
                 $actualMethod = $order->get_payment_method();
-            }
-            else
-            {
+            } else {
                 $actualMethod = get_post_meta( $order->get_id(), '_payment_method', true );
             }
-            return $actualMethod === 'btcpay';
+
+            return (false !== strpos($actualMethod, 'btcpay'));
+        }
+
+      /**
+       * Determine if an additional token payment method is used.
+       *
+       * @return bool
+       */
+        public function is_additional_token_method()
+        {
+            if (false !== strpos($this->id, 'btcpay_')) {
+                return true;
+            }
+            return false;
+        }
+
+      /**
+       * Check upload directory for a custom icon and return the full url if
+       * it exists.
+       *
+       * @param $filename
+       *   The filename to search for. e.g. bitcoin.png
+       * @return string|null
+       */
+        public function load_custom_icon($filename)
+        {
+            $uploads_storage = wp_get_upload_dir();
+            if (file_exists($uploads_storage['basedir'] . "/{$filename}")) {
+                return $uploads_storage['baseurl'] . "/{$filename}";
+            }
+            return null;
         }
 
         public function __destruct()
@@ -268,17 +333,17 @@ function woocommerce_btcpay_init()
                     'default'     => __('Bitcoin', 'btcpay'),
                     'desc_tip'    => true,
                ),
-                'description' => array(
+               'description' => array(
                     'title'       => __('Customer Message', 'btcpay'),
                     'type'        => 'textarea',
                     'description' => __('Message to explain how the customer will be paying for the purchase.', 'btcpay'),
                     'default'     => 'You will be redirected to BTCPay to complete your purchase.',
                     'desc_tip'    => true,
                ),
-                'api_token' => array(
+               'api_token' => array(
                     'type'        => 'api_token'
                ),
-                'transaction_speed' => array(
+               'transaction_speed' => array(
                     'title'       => __('Invoice pass to "confirmed" state after', 'btcpay'),
                     'type'        => 'select',
                     'description' => 'An invoice becomes confirmed after the payment has...',
@@ -292,10 +357,10 @@ function woocommerce_btcpay_init()
                     'default' => 'default',
                     'desc_tip'    => true,
                ),
-                'order_states' => array(
+               'order_states' => array(
                     'type' => 'order_states'
                ),
-                'debug' => array(
+               'debug' => array(
                     'title'       => __('Debug Log', 'btcpay'),
                     'type'        => 'checkbox',
                     'label'       => sprintf(__('Enable logging <a href="%s" class="button">View Logs</a>', 'btcpay'), $logs_href),
@@ -303,7 +368,7 @@ function woocommerce_btcpay_init()
                     'description' => sprintf(__('Log BTCPay events, such as IPN requests, inside <code>%s</code>', 'btcpay'), wc_get_log_file_path('btcpay')),
                     'desc_tip'    => true,
                ),
-                'notification_url' => array(
+               'notification_url' => array(
                     'title'       => __('Notification URL', 'btcpay'),
                     'type'        => 'url',
                     'description' => __('BTCPay will send IPNs for orders to this URL with the BTCPay invoice data', 'btcpay'),
@@ -311,7 +376,7 @@ function woocommerce_btcpay_init()
                     'placeholder' => WC()->api_request_url('WC_Gateway_BtcPay'),
                     'desc_tip'    => true,
                ),
-                'redirect_url' => array(
+               'redirect_url' => array(
                     'title'       => __('Redirect URL', 'btcpay'),
                     'type'        => 'url',
                     'description' => __('After paying the BTCPay invoice, users will be redirected back to this URL', 'btcpay'),
@@ -319,7 +384,14 @@ function woocommerce_btcpay_init()
                     'placeholder' => $this->get_return_url(),
                     'desc_tip'    => true,
                ),
-                'support_details' => array(
+               'additional_tokens' => array(
+                  'title'       => __('Additional token configuration', 'btcpay'),
+                  'type'        => 'textarea',
+                  'description' => __('You can configure additional tokens here, one per line. e.g. "HAT;Hat Token;promotion" See documentation for details. Each one will be available as their own payment method.', 'btcpay'),
+                  'default'     => '',
+                  'desc_tip'    => true,
+                ),
+               'support_details' => array(
                     'title'       => __( 'Plugin & Support Information', 'btcpay' ),
                     'type'        => 'title',
                     'description' => sprintf(__('This plugin version is %s and your PHP version is %s. If you need assistance, please come on our chat https://chat.btcpayserver.org. Thank you for using BTCPay!', 'btcpay'), constant("BTCPAY_VERSION"), PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION),
@@ -756,6 +828,11 @@ function woocommerce_btcpay_init()
             $invoice->setFullNotifications(true);
             $invoice->setExtendedNotifications(true);
 
+            // Handle additional tokens and enforce them for invoice payment.
+            if ($this->is_additional_token_method()) {
+                $invoice->setPaymentCurrencies(array($this->token_symbol));
+            }
+
             // Add a priced item to the invoice
             $item = new \Bitpay\Item();
 
@@ -767,11 +844,24 @@ function woocommerce_btcpay_init()
             }
 
             $order_total = $order->calculate_totals();
-            if (true === isset($order_total) && false === empty($order_total)) {
+            if (!empty($order_total)) {
                 $order_total = (float)$order_total;
-                if($order_total == 0 || $order_total === '0')
-                    throw new \Bitpay\Client\ArgumentException("Price must be formatted as a float ". $order_total);
-                $item->setPrice($order_total);
+                if (!is_float($order_total)) {
+                  throw new \Bitpay\Client\ArgumentException("Price must be formatted as a float ". $order_total);
+                }
+
+                // For promotion tokens we need to set the price to 1 (per item quantity).
+                // The idea is that 1 token is like a voucher.
+                if ($this->is_additional_token_method() && $this->token_mode === 'promotion') {
+                    // Set the invoice currency to the promotion token.
+                    $invoice->setCurrency(new \Bitpay\CurrencyUnrestricted($this->token_symbol));
+                    // For each of the purchased items quantity we charge 1 token.
+                    $total_quantity = (float) $this->get_order_total_item_quantity($order);
+                    $item->setPrice($total_quantity);
+                } else {
+                    $item->setPrice($order_total);
+                }
+
                 $taxIncluded = $order->get_cart_tax();
                 $item->setTaxIncluded($taxIncluded);
             } else {
@@ -1243,16 +1333,66 @@ function woocommerce_btcpay_init()
                 wp_die('Invalid server fingerprint generated');
             }
 
+        }
+
+      /**
+       * Return the total quantity of the whole order for all line items.
+       */
+        public function get_order_total_item_quantity(WC_Order $order)
+        {
+            $total = 0;
+            foreach ($order->get_items() as $item_id => $item ) {
+                $total += $item->get_quantity();
+            }
+
+          return $total;
+        }
     }
-}
     /**
-    * Add BitPay Payment Gateway to WooCommerce
+    * Add BTCPay Payment Gateways to WooCommerce
     **/
     function wc_add_btcpay($methods)
     {
+        // Add main BTCPay payment method class.
         $methods[] = 'WC_Gateway_BtcPay';
 
+        // Add additional tokens as speparate payment methods.
+        if ($additional_tokens = btcpay_get_additional_tokens()) {
+            foreach ($additional_tokens as $token) {
+              $methods[] = $token['classname'];
+            }
+        }
+
         return $methods;
+    }
+
+  /**
+   * Check and return any configured additional tokens.
+   *
+   * @return array|null
+   */
+    function btcpay_get_additional_tokens()
+    {
+        $btcpay_settings = get_option('woocommerce_btcpay_settings', NULL);
+
+        if (!empty($btcpay_settings['additional_tokens'])) {
+            $tokens = [];
+            $tokens_data = str_getcsv($btcpay_settings['additional_tokens'], "\n");
+            foreach ($tokens_data as $row) {
+              $token_config = str_getcsv($row, ";");
+              // Todo: check/make sure token config is complete.
+              $token['symbol'] = sanitize_text_field($token_config[0]);
+              $token['name'] = sanitize_text_field($token_config[1]);
+              $token['mode'] = sanitize_text_field($token_config[2]);
+              $token['icon'] = sanitize_text_field($token_config[3]);
+              $token['classname'] = "WC_Gateway_BtcPay_{$token['symbol']}";
+              $tokens[] = $token;
+            }
+
+            return !empty($tokens) ? $tokens : null;
+        }
+
+        return null;
     }
 
     add_filter('woocommerce_payment_gateways', 'wc_add_btcpay');


### PR DESCRIPTION
The token payment methods are generated on the fly and allow them to integrate nicely with existing woocommerce plugins and open lot of use cases like discounts per payment method. Allowing different tokens for different products or by shipping zone etc.

Beside all the other token support, this also allows us to generate separate payment methods for Lightning Network (LN), e.g. you can configure your store in such a way that certain products can only be paid with LN; or customer gets a discount etc.

![image](https://user-images.githubusercontent.com/1136761/104965120-50508c80-59de-11eb-913a-0116520ff278.png)

![image](https://user-images.githubusercontent.com/1136761/104965145-5d6d7b80-59de-11eb-9a78-f4ccb609dc12.png)

![image](https://user-images.githubusercontent.com/1136761/104965154-64948980-59de-11eb-99c7-40392ab0ee20.png)


**Assumptions/Features:**
- if users chooses such a payment method the invoice payment currency is set to this specific token and **will not** have a currency switch on the BTCPay server payment page (like the current/main payment method has)
- payment methods can be enabled/disabled like any other (but they do not have their own config form for now as it would bloat the class generation code too much)
- you can differentiate between payment and promotion tokens (more information below)
- you can set custom icons
- token symbols need to match between woocommerce and BTCPay Server (e.g. ETH, USDt needs to be configured on both)

**Data input/configuration**
For now tokens are configured via a CSV style input (any hints on how to do nested config options in WP appreciated).

**Dynamic payment class generation**
The current implementation uses [eval()](https://www.php.net/manual/en/function.eval.php) to generate the dynamic classes. While our use case is the exact reason that function exists it is common practice to try to avoid using it. But maybe it is fine with some additional data validation.

I tried to do it with anonymous classes but the problem here is that while passing the variables to the constructor works when the BTCPay class is instantiated, woocommerce loads the payment classes itself without passing any variables to the constructor and this breaks the code. But I have an idea that could make it work without passing the variables but fetching the token config by the token class name (which is a bit ugly itself but patching woocommerce is also no option here).

Another option would be to generate the classes and write them into the filesystem. This would mean we need to make sure to cleanup things and do housekeeping which is not ideal. It would also now work on enterprise cloud services/infrastructure like Platform.sh that have read-only filesystems.


----

**Configuration / Setup**

I will write up a better documentation with screenshots in the docs but here are the notes for now:

In the BTCPay settings you have  a new setting “Additional token configuration” where you can input the assets data in the following CSV format with the following column definitions:

1. token symbol (this needs to match the symbol on BTCPay Server)
2. display name (shown on checkout)
3. type: this can be “payment” or “promotion” (maybe this gets changed to “precision” with value 0 meaning to be a promo token)
4. url to token symbol (can be empty; you can upload in media manager and copy the url or link to an external site/CDN)

Important: Text needs to be enclosed by quotes and separated by semicolon; each asset in a new line

Example:
```
"USDt";"USDt (Theter)";"payment";"https://wordpress.demo.btcpay.tech/wp-content/uploads/2021/01/usdt.png"
"eKr";"eKrona Token";"promotion";""
"SCAM";"Scamcoin Token";"promotion";""
```

After saving you will see each asset to be available as payment method. You can enable/disable them like any other payment method. They won’t have any settings itself for now though (everything is configured by the CSV data).

You can check some example products here (please do not pay (mainnet) but feel free to go through checkout until you see the BTCPay payment page)

https://wordpress.demo.btcpay.tech

