### PR TITLE
updates links

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ $ ./node_modules/.bin/grunt build
 
 ### WooCommerce Support
 
-* [Homepage](http://www.woothemes.com/woocommerce/)
-* [Documentation](http://docs.woothemes.com)
-* [Support](https://support.woothemes.com)
+* [Homepage](http://woocommerce.com)
+* [Documentation](http://docs.woocommerce.com)
+* [Support](https://wordpress.org/support/plugin/woocommerce/)
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ $ ./node_modules/.bin/grunt build
 
 ### WooCommerce Support
 
-* [Homepage](http://woocommerce.com)
-* [Documentation](http://docs.woocommerce.com)
+* [Homepage](https://woocommerce.com/)
+* [Documentation](https://docs.woocommerce.com)
 * [Support](https://wordpress.org/support/plugin/woocommerce/)
 
 ## Troubleshooting


### PR DESCRIPTION
WooThemes rebranded as WooCommerce quite some time ago. Support for users or the free WooCommerce plugin is handled on the public forums on WordPress.org