### PR TITLE
Enable plugin localization

### DIFF
--- a/src/class-wc-gateway-btcpay.php
+++ b/src/class-wc-gateway-btcpay.php
@@ -5,13 +5,16 @@
     Plugin URI:  https://wordpress.org/plugins/btcpay-for-woocommerce
     Description: Enable your WooCommerce store to accept Bitcoin with BTCPay.
     Author:      BTCPay
-    Text Domain: BTCPay
     Author URI:  https://github.com/btcpayserver
 
     Version:           3.0.12
     License:           Copyright 2011-2018 BTCPay & BitPay Inc., MIT License
     License URI:       https://github.com/btcpayserver/woocommerce-plugin/blob/master/LICENSE
     GitHub Plugin URI: https://github.com/btcpayserver/woocommerce-plugin
+
+    Text Domain: btcpay-for-woocommerce
+    Domain Path: languages
+
  */
 
 
@@ -48,8 +51,20 @@ if (false === class_exists('Bitpay\Token')) {
     include_once(__DIR__ . '/lib/Bitpay/Token.php');
 }
 
+/**
+ * Load translations
+ */
+function btcpay_load_textdomain() {
+    $slug = 'btcpay-for-woocommerce';
+    $locale = get_locale();
+    $locale = apply_filters('plugin_locale', $locale, $slug);
+    load_textdomain($slug, WP_LANG_DIR . '/plugins/' . $slug . '-' . $locale . '.mo' );
+    load_plugin_textdomain($slug, false, dirname(plugin_basename( __FILE__ )) . '/languages/');
+}
+
 // Ensures WooCommerce is loaded before initializing the BitPay plugin
 add_action('plugins_loaded', 'woocommerce_btcpay_init', 0);
+add_action('plugins_loaded', 'btcpay_load_textdomain');
 add_action( 'admin_notices', 'fx_admin_notice_show_migration_message' );
 register_activation_hook(__FILE__, 'woocommerce_btcpay_activate');
 
@@ -89,7 +104,7 @@ function woocommerce_btcpay_init()
             $this->id                 = 'btcpay';
             $this->icon               = plugin_dir_url(__FILE__).'assets/img/icon.png';
             $this->has_fields         = false;
-            $this->order_button_text  = __('Proceed to BTCPay', 'btcpay');
+            $this->order_button_text  = __('Proceed to BTCPay', 'btcpay-for-woocommerce');
             $this->method_title       = 'BTCPay';
             $this->method_description = 'BTCPay allows you to accept bitcoin payments on your WooCommerce store.';
 
@@ -299,16 +314,16 @@ function woocommerce_btcpay_init()
 
             $this->form_fields = array(
                 'title' => array(
-                    'title'       => __('Title', 'btcpay'),
+                    'title'       => __('Title', 'btcpay-for-woocommerce'),
                     'type'        => 'text',
-                    'description' => __('Controls the name of this payment method as displayed to the customer during checkout.', 'btcpay'),
-                    'default'     => __('Bitcoin', 'btcpay'),
+                    'description' => __('Controls the name of this payment method as displayed to the customer during checkout.', 'btcpay-for-woocommerce'),
+                    'default'     => __('Bitcoin', 'btcpay-for-woocommerce'),
                     'desc_tip'    => true,
                ),
                'description' => array(
-                    'title'       => __('Customer Message', 'btcpay'),
+                    'title'       => __('Customer Message', 'btcpay-for-woocommerce'),
                     'type'        => 'textarea',
-                    'description' => __('Message to explain how the customer will be paying for the purchase.', 'btcpay'),
+                    'description' => __('Message to explain how the customer will be paying for the purchase.', 'btcpay-for-woocommerce'),
                     'default'     => 'You will be redirected to BTCPay to complete your purchase.',
                     'desc_tip'    => true,
                ),
@@ -316,7 +331,7 @@ function woocommerce_btcpay_init()
                     'type'        => 'api_token'
                ),
                'transaction_speed' => array(
-                    'title'       => __('Invoice pass to "confirmed" state after', 'btcpay'),
+                    'title'       => __('Invoice pass to "confirmed" state after', 'btcpay-for-woocommerce'),
                     'type'        => 'select',
                     'description' => 'An invoice becomes confirmed after the payment has...',
                     'options'     => array(
@@ -333,49 +348,49 @@ function woocommerce_btcpay_init()
                     'type' => 'order_states'
                ),
                'debug' => array(
-                    'title'       => __('Debug Log', 'btcpay'),
+                    'title'       => __('Debug Log', 'btcpay-for-woocommerce'),
                     'type'        => 'checkbox',
-                    'label'       => sprintf(__('Enable logging <a href="%s" class="button">View Logs</a>', 'btcpay'), $logs_href),
+                    'label'       => sprintf(__('Enable logging <a href="%s" class="button">View Logs</a>', 'btcpay-for-woocommerce'), $logs_href),
                     'default'     => 'no',
-                    'description' => sprintf(__('Log BTCPay events, such as IPN requests, inside <code>%s</code>', 'btcpay'), wc_get_log_file_path('btcpay')),
+                    'description' => sprintf(__('Log BTCPay events, such as IPN requests, inside <code>%s</code>', 'btcpay-for-woocommerce'), wc_get_log_file_path('btcpay')),
                     'desc_tip'    => true,
                ),
                'notification_url' => array(
-                    'title'       => __('Notification URL', 'btcpay'),
+                    'title'       => __('Notification URL', 'btcpay-for-woocommerce'),
                     'type'        => 'url',
-                    'description' => __('BTCPay will send IPNs for orders to this URL with the BTCPay invoice data', 'btcpay'),
+                    'description' => __('BTCPay will send IPNs for orders to this URL with the BTCPay invoice data', 'btcpay-for-woocommerce'),
                     'default'     => '',
                     'placeholder' => WC()->api_request_url('WC_Gateway_BtcPay'),
                     'desc_tip'    => true,
                ),
                'redirect_url' => array(
-                    'title'       => __('Redirect URL', 'btcpay'),
+                    'title'       => __('Redirect URL', 'btcpay-for-woocommerce'),
                     'type'        => 'url',
-                    'description' => __('After paying the BTCPay invoice, users will be redirected back to this URL', 'btcpay'),
+                    'description' => __('After paying the BTCPay invoice, users will be redirected back to this URL', 'btcpay-for-woocommerce'),
                     'default'     => '',
                     'placeholder' => $this->get_return_url(),
                     'desc_tip'    => true,
                ),
                'additional_tokens' => array(
-                  'title'       => __('Additional token configuration', 'btcpay'),
+                  'title'       => __('Additional token configuration', 'btcpay-for-woocommerce'),
                   'type'        => 'textarea',
-                  'description' => __('You can configure additional tokens here, one per line. e.g. "HAT;Hat Token;promotion" See documentation for details. Each one will be available as their own payment method.', 'btcpay'),
+                  'description' => __('You can configure additional tokens here, one per line. e.g. "HAT;Hat Token;promotion" See documentation for details. Each one will be available as their own payment method.', 'btcpay-for-woocommerce'),
                   'default'     => '',
                   'desc_tip'    => true,
                ),
 			   'additional_tokens_limit_payment' => array(
-					'title'       => __('Additional tokens: Enforce payment tokens', 'btcpay'),
+					'title'       => __('Additional tokens: Enforce payment tokens', 'btcpay-for-woocommerce'),
 					'type'        => 'checkbox',
-					'label'       => __('Limit default payment methods to listed "payment" tokens.', 'btcpay'),
+					'label'       => __('Limit default payment methods to listed "payment" tokens.', 'btcpay-for-woocommerce'),
 					'default'     => 'no',
 					'value'       => 'yes',
-					'description' => __('This will override the default btcpay payment method (defaults to all supported by BTCPay Server) and enforce to tokens of type "payment". This is useful if you want full control on what is available on BTCPay Server payment page.', 'btcpay'),
+					'description' => __('This will override the default btcpay payment method (defaults to all supported by BTCPay Server) and enforce to tokens of type "payment". This is useful if you want full control on what is available on BTCPay Server payment page.', 'btcpay-for-woocommerce'),
 					'desc_tip'    => true,
 			   ),
                'support_details' => array(
                     'title'       => __( 'Plugin & Support Information', 'btcpay' ),
                     'type'        => 'title',
-                    'description' => sprintf(__('This plugin version is %s and your PHP version is %s. If you need assistance, please come on our chat https://chat.btcpayserver.org. Thank you for using BTCPay!', 'btcpay'), constant("BTCPAY_VERSION"), PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION),
+                    'description' => sprintf(__('This plugin version is %s and your PHP version is %s. If you need assistance, please come on our chat https://chat.btcpayserver.org. Thank you for using BTCPay!', 'btcpay-for-woocommerce'), constant("BTCPAY_VERSION"), PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION),
                ),
            );
 
@@ -1155,7 +1170,7 @@ function woocommerce_btcpay_init()
                         $this->log('    [Info] This order has not been updated yet so setting new status...');
                         if($paid_status !== 'BTCPAY_IGNORE')
                             $order->update_status($paid_status);
-                        $order->add_order_note(__('BTCPay invoice paid. Awaiting network confirmation and payment completed status.', 'btcpay'));
+                        $order->add_order_note(__('BTCPay invoice paid. Awaiting network confirmation and payment completed status.', 'btcpay-for-woocommerce'));
                         break;
 
                     // The "confirmed" status is sent when the payment is
@@ -1164,7 +1179,7 @@ function woocommerce_btcpay_init()
                         $this->log('    [Info] This order has not been updated yet so setting confirmed status...');
                         if($confirmed_status !== 'BTCPAY_IGNORE')
                             $order->update_status($confirmed_status);
-                        $order->add_order_note(__('BTCPay invoice confirmed. Awaiting payment completed status.', 'btcpay'));
+                        $order->add_order_note(__('BTCPay invoice confirmed. Awaiting payment completed status.', 'btcpay-for-woocommerce'));
                         break;
 
                     // The complete status is when the Bitcoin network
@@ -1176,7 +1191,7 @@ function woocommerce_btcpay_init()
                         $order->payment_complete();
                         if($complete_status !== 'BTCPAY_IGNORE')
                             $order->update_status($complete_status);
-                        $order->add_order_note(__('BTCPay invoice payment completed. Payment credited to your merchant account.', 'btcpay'));
+                        $order->add_order_note(__('BTCPay invoice payment completed. Payment credited to your merchant account.', 'btcpay-for-woocommerce'));
                         break;
 
                     // This order is invalid for some reason.
@@ -1186,14 +1201,14 @@ function woocommerce_btcpay_init()
 
                         $this->log('    [Info] This order has a problem so setting "invalid" status...');
                         if($invalid_status !== 'BTCPAY_IGNORE')
-                            $order->update_status($invalid_status, __('Bitcoin payment is invalid for this order! The payment was not confirmed by the network within on time. Do not ship the product for this order!', 'btcpay'));
+                            $order->update_status($invalid_status, __('Bitcoin payment is invalid for this order! The payment was not confirmed by the network within on time. Do not ship the product for this order!', 'btcpay-for-woocommerce'));
                         break;
 
                     case 'expired':
 
                         $this->log('    [Info] The invoice is in the "expired" status...');
                         if($expired_status !== 'BTCPAY_IGNORE')
-                            $order->update_status($expired_status, __('Bitcoin payment has expired for this order! The payment was not broadcasted before its expiration. Do not ship the product for this order!', 'btcpay'));
+                            $order->update_status($expired_status, __('Bitcoin payment has expired for this order! The payment was not broadcasted before its expiration. Do not ship the product for this order!', 'btcpay-for-woocommerce'));
                         break;
 
                     // There was an unknown message received.
@@ -1212,15 +1227,15 @@ function woocommerce_btcpay_init()
                 {
                     $this->log('    [Info] The invoice has received a payment after expiration...');
                     if($event_invoice_paidAfterExpiration !== 'BTCPAY_IGNORE')
-                        $order->update_status($event_invoice_paidAfterExpiration , __('A payment has arrived late for this order!', 'btcpay'));
-                    $order->add_order_note(__('A payment has been received after expiration', 'btcpay'));
+                        $order->update_status($event_invoice_paidAfterExpiration , __('A payment has arrived late for this order!', 'btcpay-for-woocommerce'));
+                    $order->add_order_note(__('A payment has been received after expiration', 'btcpay-for-woocommerce'));
                 }
                 if ($event['code'] === 2000)
                 {
                     $this->log('    [Info] The invoice has expired while a partial payment has been sent...');
                     if($event_invoice_expiredPaidPartial !== 'BTCPAY_IGNORE')
                         $order->update_status($event_invoice_expiredPaidPartial , __('The invoice has expired while a partial payment has been sent'));
-                    $order->add_order_note(__('The invoice has expired while a partial payment has been sent', 'btcpay'));
+                    $order->add_order_note(__('The invoice has expired while a partial payment has been sent', 'btcpay-for-woocommerce'));
                 }
             }
             $this->log('    [Info] Leaving ipn_callback()...');

--- a/src/languages/btcpay-for-woocommerce.pot
+++ b/src/languages/btcpay-for-woocommerce.pot
@@ -1,0 +1,147 @@
+# Copyright (C) 2021 BTCPay
+# This file is distributed under the Copyright 2011-2018 BTCPay & BitPay Inc., MIT License.
+msgid ""
+msgstr ""
+"Project-Id-Version: BTCPay for WooCommerce 3.0.12\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/src\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2021-06-05T16:53:37+02:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.5.0\n"
+"X-Domain: btcpay-for-woocommerce\n"
+
+#. Plugin Name of the plugin
+msgid "BTCPay for WooCommerce"
+msgstr ""
+
+#. Plugin URI of the plugin
+msgid "https://wordpress.org/plugins/btcpay-for-woocommerce"
+msgstr ""
+
+#. Description of the plugin
+msgid "Enable your WooCommerce store to accept Bitcoin with BTCPay."
+msgstr ""
+
+#. Author of the plugin
+msgid "BTCPay"
+msgstr ""
+
+#. Author URI of the plugin
+msgid "https://github.com/btcpayserver"
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:107
+msgid "Proceed to BTCPay"
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:317
+msgid "Title"
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:319
+msgid "Controls the name of this payment method as displayed to the customer during checkout."
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:320
+msgid "Bitcoin"
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:324
+msgid "Customer Message"
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:326
+msgid "Message to explain how the customer will be paying for the purchase."
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:334
+msgid "Invoice pass to \"confirmed\" state after"
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:351
+msgid "Debug Log"
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:353
+msgid "Enable logging <a href=\"%s\" class=\"button\">View Logs</a>"
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:355
+msgid "Log BTCPay events, such as IPN requests, inside <code>%s</code>"
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:359
+msgid "Notification URL"
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:361
+msgid "BTCPay will send IPNs for orders to this URL with the BTCPay invoice data"
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:367
+msgid "Redirect URL"
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:369
+msgid "After paying the BTCPay invoice, users will be redirected back to this URL"
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:375
+msgid "Additional token configuration"
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:377
+msgid "You can configure additional tokens here, one per line. e.g. \"HAT;Hat Token;promotion\" See documentation for details. Each one will be available as their own payment method."
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:382
+msgid "Additional tokens: Enforce payment tokens"
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:384
+msgid "Limit default payment methods to listed \"payment\" tokens."
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:387
+msgid "This will override the default btcpay payment method (defaults to all supported by BTCPay Server) and enforce to tokens of type \"payment\". This is useful if you want full control on what is available on BTCPay Server payment page."
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:393
+msgid "This plugin version is %s and your PHP version is %s. If you need assistance, please come on our chat https://chat.btcpayserver.org. Thank you for using BTCPay!"
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:1173
+msgid "BTCPay invoice paid. Awaiting network confirmation and payment completed status."
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:1182
+msgid "BTCPay invoice confirmed. Awaiting payment completed status."
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:1194
+msgid "BTCPay invoice payment completed. Payment credited to your merchant account."
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:1204
+msgid "Bitcoin payment is invalid for this order! The payment was not confirmed by the network within on time. Do not ship the product for this order!"
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:1211
+msgid "Bitcoin payment has expired for this order! The payment was not broadcasted before its expiration. Do not ship the product for this order!"
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:1230
+msgid "A payment has arrived late for this order!"
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:1231
+msgid "A payment has been received after expiration"
+msgstr ""
+
+#: class-wc-gateway-btcpay.php:1238
+msgid "The invoice has expired while a partial payment has been sent"
+msgstr ""


### PR DESCRIPTION
- Fix the Text Domain
  https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/
  ```
  The text domain must match the slug of the plugin. If your plugin is a
  single file called my-plugin.php or it is contained in a folder called
  my-plugin the domain name must be my-plugin.
  ```

- Create localization template under `languages/` subdirectory
  https://developer.wordpress.org/cli/commands/i18n/make-pot/
  ```
  $ cd wp-content/plugins/btcpay-for-woocommerce
  $ wp i18n make-pot . languages/btcpay-for-woocommerce.pot
  ...
  Success: POT file successfully generated!
  ```

- Add `btcpay_load_textdomain()` to enable localization

---

Should help with fixing #38

Tested by creating a custom l10n:
- copy .pot to properly named .po (e.g. `btcpay-for-woocommerce-es_ES.po`)
- translate the strings inside
- generate an .mo file: `$ wp i18n make-mo btcpay-for-woocommerce-es_ES.po`

And perhaps the Translation BUI at https://translate.wordpress.org/projects/wp-plugins/btcpay-for-woocommerce/ will become available automatically with this.